### PR TITLE
Deprecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Liqo resource plugins
 
+⚠️ This Project is Deprecated ⚠️
+
+Please note: This repository is no longer actively maintained and is considered deprecated. We encourage you to explore alternative solutions or repositories that are actively developed.
+
+------
+
 This repository contains resource plugins that you can use to customize the amount of resources that [Liqo](https://github.com/liqotech/liqo) offers to each foreign cluster.
 You can either use the plugin that fits your use case or decide to start from an existing one and extend/modify it according to your needs. **Resource plugins are supported in Liqo v0.6.0 and above**.
 


### PR DESCRIPTION
This PR adds a banner inside the README file to deprecate this project.

After the liqo v1.0.0 refactoring, the dashboard won't be compatible with the new liqo APIs anymore.